### PR TITLE
Fixing Loaderror for Ruby version >=2.7

### DIFF
--- a/lib/proc_source.rb
+++ b/lib/proc_source.rb
@@ -9,8 +9,8 @@
 
 begin
   require 'irb/ruby-token'  # ruby <2.7
-rescue
-  require 'lib/core_ext'  # ruby >=2.7
+rescue LoadError
+  require 'core_ext'        # ruby >=2.7
 end
 
 require 'irb/ruby-lex'


### PR DESCRIPTION
Solves https://github.com/onetimesecret/onetimesecret/issues/137 and https://github.com/delano/storable/issues/6 